### PR TITLE
wiki/projects: add envdoc documentation tool

### DIFF
--- a/Projects.md
+++ b/Projects.md
@@ -753,6 +753,7 @@ See also [SQLDrivers page](SQLDrivers).
 
 ### Documentation
 
+  * [envdoc](https://github.com/g4s8/envdoc) - Generate documentation for environment variables from Go source files.
   * [godocdown](https://github.com/robertkrimen/godocdown) - Format package documentation (godoc) as GitHub friendly Markdown
   * [golangdoc](https://github.com/golang-china/golangdoc) - Godoc for Golang, support translate.
   * [Mango](http://code.google.com/p/mango-doc/) - Automatically generate unix man pages from Go sources


### PR DESCRIPTION
Add `envdoc` go generator tool which can extract documentation for environment variables from go source files and build Markdown, HTML and plaintext documents. Already added to awesome-go repo: https://github.com/avelino/awesome-go/commit/768d09725525eea938814316c0f2db8d5b6ebe48