### PR TITLE
SliceTricks: use builtin clear

### DIFF
--- a/SliceTricks.md
+++ b/SliceTricks.md
@@ -187,9 +187,7 @@ for _, x := range a {
 For elements which must be garbage collected, the following code can be included afterwards:
 
 ```go
-for i := len(b); i < len(a); i++ {
-	a[i] = nil // or the zero value of T
-}
+clear(a[len(b):])
 ```
 
 ### Reversing


### PR DESCRIPTION
After filtering without allocating, it's recommended to loop over the underlying slice `a` and setting all unneeded values to `nil` manually if they're to be gc'ed.

Instead, one might simply use the builtin `clear` on the sub-slice starting at the end of `b`.