### PR TITLE
Extend description of GOAMD=v4

### DIFF
--- a/MinimumRequirements.md
+++ b/MinimumRequirements.md
@@ -86,7 +86,7 @@ Each level differs in the set of x86 instructions that the compiler can include 
 * GOAMD64=v1 (default): The baseline. Exclusively generates instructions that all 64-bit x86 processors can execute.
 * GOAMD64=v2: all v1 instructions, plus CMPXCHG16B, LAHF, SAHF, POPCNT, SSE3, SSE4.1, SSE4.2, SSSE3.
 * GOAMD64=v3: all v2 instructions, plus AVX, AVX2, BMI1, BMI2, F16C, FMA, LZCNT, MOVBE, OSXSAVE.
-* GOAMD64=v4: all v3 instructions, plus AVX512F, AVX512BW, AVX512CD, AVX512DQ, AVX512VL.
+* GOAMD64=v4: all v3 instructions, plus AVX512F, AVX512BW, AVX512CD, AVX512DQ, AVX512VL, and VPBROADCASTB with a general-purpose register operand.
 
 Setting, for example, GOAMD64=v3, will allow the Go compiler to use AVX2 instructions in the generated binaries (which may improve performance in some cases); but these binaries will not run on older x86 processors that don't support AVX2.
 


### PR DESCRIPTION
This code is gated on GOAMD=v4, so we should include that case in the wiki. 
https://github.com/golang/go/blob/608acff8479640b00c85371d91280b64f5ec9594/src/cmd/compile/internal/ssagen/intrinsics.go#L1339-L1340

The proposed text is my understanding based on [a Slack conversation](https://gophers.slack.com/archives/C0VP8EF3R/p1737842418886279) with Dominik Honnef.
