### PR TITLE
Conferences: add upcoming GopherCon Latam 2026

### DIFF
--- a/Conferences.md
+++ b/Conferences.md
@@ -8,16 +8,12 @@ Please keep all items in chronological order.
 
 | Name |  Date | Location | Website | CFP |
 | --- | --- | --- | --- | --- |
-| GopherCon Europe | 2025-06-16-19 | Berlin, Germany | https://gophercon.eu/ | https://forms.gle/t1aS1H8fChdVgYbR9 |
-| Go South Africa | 2025-08-06-07 | Online | https://gopherconf.co.za/ | |
-| GopherCon UK | 2025-08-13-15 | London, UK | https://www.gophercon.co.uk/ | https://www.gophercon.co.uk/call-for-papers |
-| GopherCon | 2025-08-26-28 | New York City, NY USA | https://www.gophercon.com/ | https://sessionize.com/gophercon-2025/ |
 | GopherCon India | 2025-09-14-15 | Jaipur, India | https://gopherconindia.org/ | https://www.papercall.io/gophercon-india-2025 |
 | Golab | 2025-10-05-07 | Florence, Italy | https://golab.io | |
 | GoWest | 2025-10-24 | Lehi, Utah, USA | https://www.gowestconf.com/ | |
 | Gophercon Africa | 2025-10-24-25 | Lagos, Nigeria | https://www.gophers.africa/ | https://www.gophers.africa/call-for-speakers |
 | GopherCon Korea | 2025-11-09 | Seoul, Korea | https://gophercon.kr/ | https://forms.gle/1GLAS481g2QRzCYs8 |
-
+| GopherCon Latam | 2026-09-02-04 | Florianópolis, SC, Brazil | https://gopherconlatam.org/ | https://www.papercall.io/gopherconlatam2026 |
 
 ## Archives
 
@@ -25,6 +21,10 @@ Please keep all items in reverse chronological order (most recent first)
 
 | Name | Date | Location | Talk, Video Archives |
 |------|------------|----------|----------------|
+| GopherCon Europe | 2025-06-16-19 | Berlin, Germany | https://gophercon.eu/ | https://forms.gle/t1aS1H8fChdVgYbR9 |
+| Go South Africa | 2025-08-06-07 | Online | https://gopherconf.co.za/ | |
+| GopherCon UK | 2025-08-13-15 | London, UK | https://www.gophercon.co.uk/ | https://www.gophercon.co.uk/call-for-papers |
+| GopherCon | 2025-08-26-28 | New York City, NY USA | https://www.gophercon.com/ | https://sessionize.com/gophercon-2025/ |
 | FOSDEM | 2025-02-01-02 | Brussels, Belgium | https://fosdem.org/2025/ | Go Devroom CFP https://github.com/go-devroom/cfp |
 | GoKonf Istanbul | 2024-11-23 | Istanbul, Türkiye | https://gokonf.com/ | https://kommunity.com/istanbul-gophers/events/sipay-gokonf-2024-b1e90b2d/cfp/ |
 | Golab | 2024-11-11-13 | Florence, Italy | https://golab.io | https://sessionize.com/golab-2024 |


### PR DESCRIPTION
Conferences: add upcoming GopherCon Latam 2026

We are hosting GopherCon Latam 2026 in Florianópolis, SC, Brazil on September 2, 2026.

It also moves past events to the other table.