### PR TITLE
GoUsers: add Iran Legal

### DIFF
--- a/GoUsers.md
+++ b/GoUsers.md
@@ -652,6 +652,7 @@ or file a [PR updating the file in Github](https://github.com/golang/wiki/blob/m
   * [eSITE](https://esite-iq.com/)
 
 ### Iran
+  * [Iran Legal](https://www.iran-legal.com) – Legal services in Persian [GitHub](https://github.com/iranlegal/iranlegalgo)
   * [Kamva](https://kamva.ir/) – Kamva eCommerce Platform [github](https://github.com/kamva/)
   * [Idpay](https://idpay.ir/) - bank gateways and a stable billing service in order to connect payments.
   * [IranBooking](https://www.iran-booking.com) - Online booking system for hotels in Iran


### PR DESCRIPTION
Add Iran Legal as a Go user in Iran with GitHub Go project link.