### PR TITLE
GoUsers: add First Point (Turkey)

### DIFF
--- a/GoUsers.md
+++ b/GoUsers.md
@@ -1412,6 +1412,7 @@ or file a [PR updating the file in Github](https://github.com/golang/wiki/blob/m
 ### Turkey
 
 - [Admongrel](http://www.admongrel.com/)
+- [First Point](https://firstpoint.com.tr) - Backend microservices
 - [Frigbo](https://frigbo.com/)
 - [Hepiyo](https://hepiyo.com/)
 - [icibot](https://icibot.com/)


### PR DESCRIPTION
Add [First Point](https://firstpoint.com.tr) to the Turkey section of GoUsers.

First Point uses Go for backend microservices.