### PR TITLE
GoUsers: fix non-country entries (Africa, Middle-East) and alphabetize country list

### DIFF
--- a/GoUsers.md
+++ b/GoUsers.md
@@ -11,7 +11,6 @@ or file a [PR updating the file in Github](https://github.com/golang/wiki/blob/m
 
 ### Countries
 
-- [Africa](#africa)
 - [Angola](#angola)
 - [Argentina](#argentina)
 - [Armenia](#armenia)
@@ -25,8 +24,8 @@ or file a [PR updating the file in Github](https://github.com/golang/wiki/blob/m
 - [Canada](#canada)
 - [Chile](#chile)
 - [China](#china)
-- [Croatia](#croatia)
 - [Colombia](#colombia)
+- [Croatia](#croatia)
 - [Denmark](#denmark)
 - [Estonia](#estonia)
 - [Finland](#finland)
@@ -37,8 +36,8 @@ or file a [PR updating the file in Github](https://github.com/golang/wiki/blob/m
 - [Hungary](#hungary)
 - [India](#india)
 - [Indonesia](#indonesia)
-- [Iraq](#iraq)
 - [Iran](#iran)
+- [Iraq](#iraq)
 - [Ireland](#ireland)
 - [Israel](#israel)
 - [Italy](#italy)
@@ -48,7 +47,6 @@ or file a [PR updating the file in Github](https://github.com/golang/wiki/blob/m
 - [Lithuania](#lithuania)
 - [Malaysia](#malaysia)
 - [Mexico](#mexico)
-- [Middle-East](#middle-east)
 - [Moldova](#moldova)
 - [Morocco](#morocco)
 - [Mozambique](#mozambique)
@@ -77,16 +75,13 @@ or file a [PR updating the file in Github](https://github.com/golang/wiki/blob/m
 - [Switzerland](#switzerland)
 - [Taiwan](#taiwan)
 - [Thailand](#thailand)
+- [Tunisia](#tunisia)
 - [Turkey](#turkey)
 - [Ukraine](#ukraine)
 - [United Arab Emirates](#united-arab-emirates)
 - [United Kingdom](#united-kingdom)
 - [United States](#united-states)
 - [Vietnam](#vietnam)
-
-### Africa
-
-- [Afariat](https://afariat.com/) - Classifieds platform in Tunisia.
 
 ### Angola
 
@@ -366,6 +361,10 @@ or file a [PR updating the file in Github](https://github.com/golang/wiki/blob/m
 - [xueqiu](https://www.xueqiu.com/)
 - [Habby](https://habby.com/)
 
+### Colombia
+
+- [Wawandco](https://wawand.co) - [github](https://github.com/wawandco)
+
 ### Croatia
 
 - [Crossvallia](https://crossvallia.hr/)
@@ -382,10 +381,6 @@ or file a [PR updating the file in Github](https://github.com/golang/wiki/blob/m
 - [SedamIT](https://www.sedamit.hr/)
 - [Syntio](https://www.syntio.net/) - [github](https://github.com/syntio)
 - [Pointer](https://pointer.hr/hr/naslovna/)
-
-### Colombia
-
-- [Wawandco](https://wawand.co) - [github](https://github.com/wawandco)
 
 ### Denmark
 
@@ -677,10 +672,6 @@ or file a [PR updating the file in Github](https://github.com/golang/wiki/blob/m
 - [Ourintake](https://ourintake.my.id)
 - [Mangko](https://mangko.net)
 
-### Iraq
-
-- [eSITE](https://esite-iq.com/)
-
 ### Iran
 
 - [Iran Legal](https://www.iran-legal.com) – Legal services in Persian [GitHub](https://github.com/iranlegal/iranlegalgo)
@@ -708,6 +699,10 @@ or file a [PR updating the file in Github](https://github.com/golang/wiki/blob/m
 - [Shafa.clinic](https://Shafa.clinic/) - best medical laser service in Iran
 - [Cafe Bazaar](https://cafebazaar.ir/?l=en/) - Iranian Android marketplace
 - [Alibaba Travels Co.](https://alibaba.ir/) - [(GitHub)](https://github.com/alibaba-go) - Iranian online travel agency
+
+### Iraq
+
+- [eSITE](https://esite-iq.com/)
 
 ### Ireland
 
@@ -1025,10 +1020,6 @@ or file a [PR updating the file in Github](https://github.com/golang/wiki/blob/m
 - [Entropy](https://entropy.tech) - Ecommerce Marketing Optimization Platform.
 - [Credijusto](https://engineering.credijusto.com/) - Financial Services
 - [Tredicom](https://www.tredicom.com/) - B2B, EDI & Ecommerce Services
-
-### Middle-East
-
-- [ThoughtBox Technologies](https://www.thoughtbox.io/) - A FinTech Solution Provider
 
 ### Moldova
 
@@ -1408,6 +1399,10 @@ or file a [PR updating the file in Github](https://github.com/golang/wiki/blob/m
 - [Xcellence Corporation](http://www.xclnc.com)
 - [Zanroo](https://www.zanroo.com/)
 - [Zarewoft](https://github.com/zarewoft)
+
+### Tunisia
+
+- [Afariat](https://afariat.com/) - Classifieds platform in Tunisia.
 
 ### Turkey
 


### PR DESCRIPTION
## What

Cleans up the country index in `GoUsers.md` so every entry is an actual country, and fixes a few alphabetization slips. No companies are lost.

## Why

**1. "Africa" is a continent, not a country.**
It was listed in the `### Countries` index and had its own `### Africa` section whose sole entry was *Afariat* — described in its own text as a "Classifieds platform in **Tunisia**." I moved that company into a new `### Tunisia` section (placed alphabetically) and removed the bogus `Africa` country entry. `South Africa` (a real country) is untouched.

**2. "Middle-East" is a region, not a country.**
Its only entry was *ThoughtBox Technologies* (`thoughtbox.io`). That same company is **already listed under India** as *ThoughtBox Online Services Pvt Ltd* (same domain; the legal entity is headquartered in Kochi, India). So the `Middle-East` entry was a duplicate — I removed the region entry and its section. Nothing is lost; the company remains under India.

**3. Alphabetization fixes** in both the index and the section bodies:
- `Colombia` now precedes `Croatia` (was reversed)
- `Iran` now precedes `Iraq` (was reversed)

## Verification

- Index links and country sections are 1:1 (71 each).
- All `###` section headers are now in alphabetical order.
- `thoughtbox.io` appears exactly once (under India).
- Diff is index/ordering only — no company URLs or descriptions changed except the relocations described above.