### PR TITLE
wiki: fix broken module diagram images by using raw GitHub URLs

### DIFF
--- a/Modules.md
+++ b/Modules.md
@@ -1162,7 +1162,7 @@ my-repo
     `-- vub
 ```
 
-![Fig. A top-level module's path is a prefix of another module's path.](https://github.com/jeanbza/module-testing/blob/master/imagery/multi_module_repo.png)
+![Fig. A top-level module's path is a prefix of another module's path.](https://raw.githubusercontent.com/jeanbza/module-testing/master/imagery/multi_module_repo.png)
 
 _Fig. A top-level module's path is a prefix of another module's path._
 

--- a/Resolving-Problems-From-Modified-Module-Path.md
+++ b/Resolving-Problems-From-Modified-Module-Path.md
@@ -75,7 +75,7 @@ This is all well and good, and should satisfy most user's problems.
 
 However, there is one situation that ends up being quite a bit more involved: when there are cycles in the module dependency graph. Consider this module dependency graph:
 
-![Module Dependency Graph With A Cycle](https://github.com/jeanbza/module-testing/blob/master/imagery/Mod%20Graph%20With%20Cycle.jpg)
+![Module Dependency Graph With A Cycle](https://raw.githubusercontent.com/jeanbza/module-testing/master/imagery/Mod%20Graph%20With%20Cycle.jpg)
 
 And, let's imagine that `some/lib` used to depend on `github.com/golang/lint`.
 
@@ -99,7 +99,7 @@ some/lib@v1.3.0 github.com/golang/lint@v0.0.0-20180702182130-06c8688daad7
 
 Visualized with [golang.org/x/exp/cmd/modgraphviz](https://pkg.go.dev/golang.org/x/exp/cmd/modgraphviz):
 
-![A Module Dependency Graph With Trailing History](https://github.com/jeanbza/module-testing/blob/master/imagery/graph1.png)
+![A Module Dependency Graph With Trailing History](https://raw.githubusercontent.com/jeanbza/module-testing/master/imagery/graph1.png)
 
 Here we see that even though the last several versions of `some/lib` correctly depend on `golang.org/x/lint`, the fact that `some/lib` and `some-other/lib` share a cycle mean that there's very likely to be a path far back in time.
 
@@ -118,7 +118,7 @@ some/lib@v1.7.1 golang.org/x/lint@v0.0.0-20181026193005-c67002cb31c3
 some-other/lib@v2.5.4 some/lib@v1.7.1
 ```
 
-![A Module Dependency Graph Without Trailing History](https://github.com/jeanbza/module-testing/blob/master/imagery/graph2.png)
+![A Module Dependency Graph Without Trailing History](https://raw.githubusercontent.com/jeanbza/module-testing/master/imagery/graph2.png)
 
 Since `some/lib` and `some-other/lib` depend on each other at the same version, there's no path backwards in time to a point where `github.com/golang/lint` is provided.
 
@@ -161,9 +161,9 @@ Note that between steps 5.b and 5.d, users are broken: a version of `some/lib` h
 
 This example explained the process for removing historical trails when there exists a cycle involving two packages in a graph, but what about if there are cycles involving more packages? For example, consider the following graphs:
 
-![Module Dependency Graph With Four Related Cycles](https://github.com/jeanbza/module-testing/blob/master/imagery/Mod%20Graph%20With%204%20Cycle_%20A.jpg)
+![Module Dependency Graph With Four Related Cycles](https://raw.githubusercontent.com/jeanbza/module-testing/master/imagery/Mod%20Graph%20With%204%20Cycle_%20A.jpg)
 
-![Module Dependency Graph With One Four Vertex Cycle](https://github.com/jeanbza/module-testing/blob/master/imagery/Mod%20Graph%20With%204%20Cycle_%20B.jpg)
+![Module Dependency Graph With One Four Vertex Cycle](https://raw.githubusercontent.com/jeanbza/module-testing/master/imagery/Mod%20Graph%20With%204%20Cycle_%20B.jpg)
 
 Each of these graphs involve cycles (the latter example) or interconnected modules (the former example) involving four modules, instead of the simple two module example we saw earlier. The process is largely the same, though, but this time in step 3 and 5 we're going to bump all four modules to non-existent future versions of each other, and similarly in steps 4 and 6 we're going to test all four modules, and in step 7 fix the go.sum of all four modules.
 


### PR DESCRIPTION
## Problem
<img width="617" height="103" alt="Screenshot 2026-07-23 at 12 06 01" src="https://github.com/user-attachments/assets/06ecc0b5-d52e-40f0-8f84-c693f41b0560" />


The module dependency diagrams on two wiki pages currently render as **broken images** on https://go.dev/wiki:

- `Modules.md` — "Multiple-Modules Repositories" section (1 diagram)
- `Resolving-Problems-From-Modified-Module-Path.md` (5 diagrams)

They are linked with `github.com/jeanbza/module-testing/blob/master/imagery/…` URLs. A `/blob/` URL returns the GitHub **file-viewer HTML page** (`Content-Type: text/html`), not the image bytes, so the browser cannot display it inside an `<img>` tag.

Verified against the live site — the served HTML contains, e.g.:

```html
<img src="https://github.com/jeanbza/module-testing/blob/master/imagery/graph1.png" alt="A Module Dependency Graph With Trailing History">
```

## Fix

Point the 6 image references at the `raw.githubusercontent.com` host, which serves the same files with the correct image content types. No page renames, no content changes — only the image host in the existing links.

| URL form | Content-Type |
| --- | --- |
| `github.com/.../blob/master/...` | `text/html` ❌ |
| `raw.githubusercontent.com/.../master/...` | `image/png` / `image/jpeg` ✅ |

All 6 raw URLs were verified to return HTTP `200` with an image content type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)