### PR TITLE
wiki: load embedded images over https to avoid mixed content

### DIFF
--- a/GoArm.md
+++ b/GoArm.md
@@ -165,7 +165,7 @@ Go version weekly.2012-03-27 +645947213cac, with timeout and GOARM 7 patches htt
 
 Successfully installed and run SVGo via go get github.com/ajstarks/svgo, tested with goplay:
 
-![http://farm8.staticflickr.com/7139/7451061716_fbb585c55f.jpg](http://farm8.staticflickr.com/7139/7451061716_fbb585c55f.jpg)
+![https://farm8.staticflickr.com/7139/7451061716_fbb585c55f.jpg](https://farm8.staticflickr.com/7139/7451061716_fbb585c55f.jpg)
 
 Division benchmark via http://codereview.appspot.com/6258067:
 

--- a/Mobile.md
+++ b/Mobile.md
@@ -105,7 +105,7 @@ You can deploy .app files by dragging and dropping them to the device.
 - Drag and drop the .app file to "Installed Apps" section.
 - Check the "Copy items if needed" option
 
-![Deploying app bundle](http://i.imgur.com/fRbQ0EQ.png)
+![Deploying app bundle](https://i.imgur.com/fRbQ0EQ.png)
 
 Alternatively, you can deploy application bundles to your iOS device by using the [ios-deploy](https://github.com/phonegap/ios-deploy) utility command line tool. Use ios-deploy to push the application to your device.
 
@@ -166,7 +166,7 @@ require (
 - Launch Android Studio.
 - File > Import Project... to import the reference project from $GOPATH/src/golang.org/x/mobile/example/bind/android.
 
-![Android Studio](http://i.imgur.com/RhNCnnH.png)
+![Android Studio](https://i.imgur.com/RhNCnnH.png)
 
 - Build and deploy the application to the device.
 
@@ -210,7 +210,7 @@ $ open ios/bind.xcodeproj
 
 Drag and drop the `Hello.framework` bundle to the Xcode project. Check "Copy items if needed" if you need a different copy of the framework bundle within the Xcode otherwise. Otherwise, modifying the Go package source code and rerunning `gomobile bind` will update the hello.framework.
 
-![Drag and drop Hello.framework](http://i.imgur.com/u88CxN9.png)
+![Drag and drop Hello.framework](https://i.imgur.com/u88CxN9.png)
 
 If you decide to keep `Hello.framework` in the main directory you have to add the main directory to the `Framework Search Paths` in the targets Build Settings.
 
@@ -218,7 +218,7 @@ If you decide to keep `Hello.framework` in the main directory you have to add th
 
 Your project layout should look like what's shown below.
 
-![Xcode project layout with Hello.framework](http://i.imgur.com/JhcSKwC.png)
+![Xcode project layout with Hello.framework](https://i.imgur.com/JhcSKwC.png)
 
 Build and run it on the simulator or an actual device (Cmd+R). When the application launches, the label on the main view will be modified with the string returned from `GoHelloGreetings` which invokes the `hello.Greetings` function.
 


### PR DESCRIPTION
## Problem

`Mobile.md` and `GoArm.md` embed screenshots via `http://` URLs. Because https://go.dev is served over HTTPS, these are **mixed content**: browsers either block the request or must silently upgrade it, so the images can fail to display.

Affected references:
- `Mobile.md` — 4× `http://i.imgur.com/…`
- `GoArm.md` — 1× `http://farm8.staticflickr.com/…`

## Fix

Switch the five references to `https://`. Each host already serves the identical file over HTTPS (verified: imgur → `200 image/png`, flickr → `200 image/jpeg`), so this is a scheme-only change with no other content edits.

_Companion to #102, which fixes the `/blob/` module-diagram images. Together they make every embedded image on the wiki load reliably on the HTTPS site._