### PR TITLE
wiki: use absolute go.dev URLs for Contribution Guide links

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -29,7 +29,7 @@ and label them with `website`.
 ## Updating contents
 
 Before making changes, ensure familiarity with the code review process outlined in
-the official [Contribution Guide](/doc/contribute).
+the official [Contribution Guide](https://go.dev/doc/contribute).
 
 ### Sending a trivial change
 
@@ -37,12 +37,12 @@ For minor updates such as fixing typos and adding missing links, you can use
 the [GitHub flow](https://docs.github.com/en/get-started/using-github/github-flow).
 Make edits from the [GitHub repo](https://github.com/golang/wiki) and open a GitHub pull request as you normally would.
 
-Additional information is available at [Sending a change via GitHub](/doc/contribute#sending_a_change_github).
+Additional information is available at [Sending a change via GitHub](https://go.dev/doc/contribute#sending_a_change_github).
 
 ### Sending a non-trivial change
 
 For larger changes, consider sending your change through Gerrit following the instructions provided in
-[Sending a change via Gerrit](/doc/contribute#sending_a_change_gerrit).
+[Sending a change via Gerrit](https://go.dev/doc/contribute#sending_a_change_gerrit).
 
 The canonical repository for wiki content is located at `go.googlesource.com/wiki`.
 


### PR DESCRIPTION
## Problem

`Contributing.md` links the Go Contribution Guide with the root-relative path `/doc/contribute` (3 occurrences). That resolves correctly on go.dev (`go.dev/doc/contribute`), but when the file is viewed **on GitHub**, GitHub resolves root-relative links against the repository root — so the link points to `https://github.com/golang/wiki/blob/master/doc/contribute` and returns a 404 ("Error loading page").

Since GitHub renders `Contributing.md` as the repo's contributing guide, this is the first link a would-be contributor clicks — and it's broken.

## Fix

Point the 3 links at the absolute `https://go.dev/doc/contribute` URL (anchors `#sending_a_change_github` / `#sending_a_change_gerrit` preserved). This resolves to the same destination on go.dev while also working on GitHub, and matches the absolute-URL style already used for every other link in the file.

Verified: `https://go.dev/doc/contribute` returns `200`, and both anchors exist on the page.